### PR TITLE
Add eap-radius auth

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 # Server will be accessible thru this DNS name
 ipsec_server_name: localhost
+# Custom IOS display name
+ipsec_ios_custom_display_name: "{{ ipsec_server_name }}"
 # Directory to store clients configs in
 ipsec_client_config_dir: /etc/ipsec.d/client_configs
 # Whether we should do iptables configuration by this role
@@ -20,5 +22,14 @@ ipsec_private_key_type: ECDSA
 #   - name: user
 #     secret: password
 ipsec_clients: []
+# Client auth type
+# available types: eap-mschapv2, eap-radius
+ipsec_client_auth_type: eap-mschapv2
+# In case of eap-radius auth, address of radius server
+ipsec_radius_server: ""
+# Radius server port
+ipsec_radius_port: 1812
+# Secret for auth on radius server
+ipsec_radius_secret: secret
 # Prefix to append to local cert names
 ipsec_prefix: ipsec

--- a/tasks/_prechecks.yml
+++ b/tasks/_prechecks.yml
@@ -5,6 +5,11 @@
   failed_when: item.name is not defined
   with_items: "{{ ipsec_clients }}"
 
+- name: VPN | Checks | Auth types
+  fail:
+    msg: "Supported auth types are: eap-mschapv2, eap-radius"
+  failed_when: ipsec_client_auth_type != 'eap-mschapv2' or ipsec_client_auth_type != 'eap-radius'
+
 - name: VPN | Checks | OS type
   fail:
     msg: "Sorry, your OS type is not supported"

--- a/tasks/setup_vpn_server.yml
+++ b/tasks/setup_vpn_server.yml
@@ -34,7 +34,9 @@
       - strongswan-libcharon
       - libcharon-standard-plugins
       - libcharon-extra-plugins
+      - libcharon-extauth-plugins
       - uuid-runtime
+      - libtss2-tcti-tabrmd0
     state: present
   register: task_result
   until: task_result is success
@@ -53,6 +55,15 @@
   template:
     src: ipsec.conf
     dest: /etc/ipsec.conf
+    mode: 0644
+    owner: root
+    group: root
+  notify: IPSec restart
+
+- name: VPN | Configuration | Ensure ipsec eap-radius config
+  template:
+    src: eap-radius.conf
+    dest: /etc/strongswan.d/charon/eap-radius.conf
     mode: 0644
     owner: root
     group: root

--- a/templates/eap-radius.conf
+++ b/templates/eap-radius.conf
@@ -1,0 +1,14 @@
+eap-radius {
+    load = yes
+    port = {{ ipsec_radius_port }}
+    secret = {{ ipsec_radius_secret }}
+    server = {{ ipsec_radius_server }}
+    dae {
+    }
+    forward {
+    }
+    servers {
+    }
+    xauth {
+    }
+}

--- a/templates/ipsec.conf
+++ b/templates/ipsec.conf
@@ -24,7 +24,7 @@ conn roadwarrior
   leftsubnet=0.0.0.0/0
   right=%any
   rightid=%any
-  rightauth=eap-mschapv2
+  rightauth={{ ipsec_client_auth_type }}
   eap_identity=%any
   rightdns={{ ipsec_vpn_dns }}
   rightsourceip={{ ipsec_vpn_network }}

--- a/templates/mobileconfig
+++ b/templates/mobileconfig
@@ -48,7 +48,7 @@
           <integer>1440</integer>
         </dict>
         <key>OnDemandEnabled</key>
-        <integer>1</integer>
+        <integer>0</integer>
         <key>OnDemandRules</key>
         <array>
           <dict>
@@ -88,7 +88,7 @@
         <integer>0</integer>
       </dict>
       <key>UserDefinedName</key>
-      <string>{{ ipsec_server_name }}</string>
+      <string>{{ ipsec_ios_custom_display_name }}</string>
       <key>VPNType</key>
       <string>IKEv2</string>
     </dict>


### PR DESCRIPTION
To be able to auth on Radius server, add an opportunity to do so:

* add choice of auth types - mschapv2 and eap-radius now available
* add radius server var to set up target server to auth on
* add radius port to connect in case of non-standard one
* add radius auth var to connect on target radius server

Also:

* add an opportunity to setup custom VPN display name on Apple devices
* disable connect on demand by default