### PR TITLE
Change condition for check auth types task.

### DIFF
--- a/tasks/_prechecks.yml
+++ b/tasks/_prechecks.yml
@@ -8,7 +8,7 @@
 - name: VPN | Checks | Auth types
   fail:
     msg: "Supported auth types are: eap-mschapv2, eap-radius"
-  failed_when: ipsec_client_auth_type != 'eap-mschapv2' or ipsec_client_auth_type != 'eap-radius'
+  failed_when: ipsec_client_auth_type != 'eap-mschapv2' and ipsec_client_auth_type != 'eap-radius'
 
 - name: VPN | Checks | OS type
   fail:


### PR DESCRIPTION
Исправляет ошибку ниже

```
	TASK [sorrowless.ipsecvpn : VPN | Checks | Auth types] 
	task path: /home/jony/personal/ansible/roles/sorrowless.ipsecvpn/tasks/_prechecks.yml:11
	fatal: [sandbox_nl]: FAILED! => {
	    "changed": false,
	    "failed_when_result": true,
	    "msg": "Supported auth types are: eap-mschapv2, eap-radius"
	}
```